### PR TITLE
pr-issue/9: Add DEV social icon and Link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 .idea
 gatsby-starter-lumen.iml
 .DS_Store
+coverage/

--- a/config.js
+++ b/config.js
@@ -13,11 +13,18 @@ module.exports = {
   menu: [
     {
       label: 'Articles',
-      path: '/'
+      path: '/',
+      target: 'internal'
     },
     {
       label: 'About me',
-      path: '/pages/about'
+      path: '/pages/about',
+      target: 'internal'
+    },
+    {
+      label: 'DEV',
+      path: 'https://dev.to/rossanodan',
+      target: 'external'
     }
   ],
   author: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "concurrently \"yarn lint:js\" \"yarn lint:scss\" \"yarn flow\"",
     "test": "jest --config ./jest/jest-config.js",
     "test:coverage": "jest --coverage --config ./jest/jest-config.js",
-    "test:watch": "jest --watch --config ./jest/jest-config.js"
+    "test:watch": "jest --watch --config ./jest/jest-config.js",
+    "test:updateSnapshot": "jest --config ./jest/jest-config.js --updateSnapshot"
   },
   "repository": "https://github.com/alxshelepenok/gatsby-starter-lumen",
   "author": "Alexander Shelepenok <alxshelepenok@gmail.com>",

--- a/src/components/Sidebar/Menu/Menu.js
+++ b/src/components/Sidebar/Menu/Menu.js
@@ -6,7 +6,8 @@ import styles from './Menu.module.scss';
 type Props = {
   menu: {
     label: string,
-    path: string
+    path: string,
+    target: string
   }[]
 };
 
@@ -15,13 +16,23 @@ const Menu = ({ menu }: Props) => (
     <ul className={styles['menu__list']}>
       {menu.map((item) => (
         <li className={styles['menu__list-item']} key={item.path}>
-          <Link
-            to={item.path}
-            className={styles['menu__list-item-link']}
-            activeClassName={styles['menu__list-item-link--active']}
-          >
-            {item.label}
-          </Link>
+          {item.target === 'external' ? (
+            <a
+              href={item.path}
+              target="_blank"
+              className={styles['menu__list-item-link']}
+            >
+              {item.label}
+            </a>
+          ) : (
+            <Link
+              to={item.path}
+              className={styles['menu__list-item-link']}
+              activeClassName={styles['menu__list-item-link--active']}
+            >
+              {item.label}
+            </Link>
+          )}
         </li>
       ))}
     </ul>

--- a/src/components/Sidebar/Menu/Menu.test.js
+++ b/src/components/Sidebar/Menu/Menu.test.js
@@ -8,11 +8,18 @@ describe('Menu', () => {
     menu: [
       {
         label: 'Item 0',
-        path: '/#0/'
+        path: '/#0/',
+        target: 'internal'
       },
       {
         label: 'Item 1',
-        path: '/#1/'
+        path: '/#1/',
+        target: 'external'
+      },
+      {
+        label: 'Item 2',
+        path: '/#2/',
+        target: 'internal'
       }
     ]
   };

--- a/src/components/Sidebar/Menu/__snapshots__/Menu.test.js.snap
+++ b/src/components/Sidebar/Menu/__snapshots__/Menu.test.js.snap
@@ -23,8 +23,19 @@ exports[`Menu renders correctly 1`] = `
       <a
         className="menu__list-item-link"
         href="/#1/"
+        target="_blank"
       >
         Item 1
+      </a>
+    </li>
+    <li
+      className="menu__list-item"
+    >
+      <a
+        className="menu__list-item-link"
+        href="/#2/"
+      >
+        Item 2
       </a>
     </li>
   </ul>

--- a/src/hooks/use-site-metadata.js
+++ b/src/hooks/use-site-metadata.js
@@ -33,6 +33,7 @@ const useSiteMetadata = () => {
             menu {
               label
               path
+              target
             }
             url
             title


### PR DESCRIPTION
## Description

This pull request adds a new link to the main menu: `DEV`. Since this link should be opened in a new tab, I added a property in GraphQL, `target` so that I can display a simple `<a href={...} target="blank"></a>` when the target is set to `external`.

I could not add the DEV link as the other social links because I couldn't find the `path` of the SVG for DEV icon. This should be improved in the future by adding the DEV link as the others.

I also updated a test and test snapshots.